### PR TITLE
README: fix main headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-META-ARP
+meta-arp
 ========
 A Yocto/OpenEmbedded layer providing BSP for Automotive Reference Platform.
 


### PR DESCRIPTION
meta-arp is not an acronym and therefore should not be spelt with all the capital letters.