### PR TITLE
Add framegrabber recipe

### DIFF
--- a/conf/machine/arp.conf
+++ b/conf/machine/arp.conf
@@ -1,0 +1,8 @@
+#@TYPE: Machine
+#@NAME: arp
+
+#@DESCRIPTION: Machine configuration for Automotive Reference Platform
+
+require conf/machine/intel-corei7-64.conf
+
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-framegrabber"

--- a/recipes-kernel/framegrabber/framegrabber_git.bb
+++ b/recipes-kernel/framegrabber/framegrabber_git.bb
@@ -1,0 +1,14 @@
+SUMMARY = "Framegrabber kernel module"
+DESCRIPTION = "Kernel module to load video frames captured from ARP cameras into memory"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+PV = "1.0+git${SRCREV}"
+PR = "r0"
+
+inherit module
+
+SRCREV = "6b3a71c1e5093d5d3a60bd34bf070fdd46768162"
+
+SRC_URI = "git://github.com/Pelagicore/framegrabber.git;protocol=https;branch=master"
+
+S = "${WORKDIR}/git"


### PR DESCRIPTION
This recipe will build and install framegrabber kernel
module on arp.

Signed-off-by: tansari <tansari@luxoft.com>