### PR TITLE
Load the arp-camera module automatically when the arp module is loaded

### DIFF
--- a/recipes-kernel/arp-driver/arp-driver/arp.conf
+++ b/recipes-kernel/arp-driver/arp-driver/arp.conf
@@ -1,0 +1,1 @@
+softdep arp post: arp-camera

--- a/recipes-kernel/arp-driver/arp-driver_git.bb
+++ b/recipes-kernel/arp-driver/arp-driver_git.bb
@@ -11,4 +11,14 @@ SRCREV = "68a414f9fcc73ec2ae5081e57de62cd24c91930a"
 
 SRC_URI = "git://github.com/Pelagicore/arp-driver.git;protocol=https;branch=master"
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += "\
+    file://arp.conf \
+"
+
 S = "${WORKDIR}/git"
+
+do_install_append() {
+    install -d ${D}${sysconfdir}/modprobe.d/
+    install -m 644 ${WORKDIR}/arp.conf ${D}${sysconfdir}/modprobe.d/arp.conf
+}


### PR DESCRIPTION
Add a modprobe.d conf file that loads the arp-camera module automatically.