### PR TITLE
Jenkinsfile: parameterize variants & images to be built

### DIFF
--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -21,7 +21,14 @@ void buildARP(String variant, String imageName) {
     }
 }
 
-parallel (
-    'arp':        { buildARP("arp",        "core-image-pelux-minimal") },
-    'arp-qtauto': { buildARP("arp-qtauto", "core-image-pelux-qtauto-neptune") },
-)
+def variantMap = [:]
+def variantList = env.VARIANT_LIST.split()
+
+variantList.each {
+    def list = it.split(":")
+    variantMap["${list[0]}"] = {
+        buildARP(list[0], list[1])
+    }
+}
+
+parallel (variantMap)


### PR DESCRIPTION
The variants and images to be built were hardcoded in
JenkinsFile. So if there was a need to add or remove
variants and images, the code needs to be changed. With
this change, a list of variant and images are defined
in Jenkins Environment, which are read dynamically in
JenkinsFile. So adding/removing variants and images do
not require code change.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>