### PR TITLE
layer.conf: fix LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "meta-arp"
 BBFILE_PATTERN_meta-arp = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-arp = "6"
 
-LAYERSERIES_COMPAT_pelux-layer = "sumo thud"
+LAYERSERIES_COMPAT_arp-layer = "sumo thud"


### PR DESCRIPTION
The macro has apparently been mistakenly copy-pasted from meta-pelux
layer. Fix the macro name, so it sets LAYERSERIES_COMPAT for meta-arp.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>