### PR TITLE
Jenkinsfile: abort previous build for the same job

### DIFF
--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -32,6 +32,26 @@ void buildARP(String variant, String imageName) {
     }
 }
 
+// If there is a build for this PR in progress, abort it
+script {
+    def jobname = env.JOB_NAME
+    def buildnum = env.BUILD_NUMBER.toInteger()
+    def job = Jenkins.instance.getItemByFullName(jobname)
+
+    for (build in job.builds) {
+        if (!build.isBuilding()) {
+            continue;
+        }
+        if (buildnum == build.getNumber().toInteger()) {
+            continue;
+        }
+
+        println("Aborting previous running build #${build.number}...")
+
+        build.doStop();
+    }
+}
+
 def variantMap = [:]
 def variantList = []
 


### PR DESCRIPTION
Script will abort previous running build if a new build is in progress.
It checks running builds of current job and abort if there are some
ecxept the current one.
It will be helpful especially for Pull Requests builds to abort build
if PR was updated.

Signed-off-by: Dmytro Iurchuk <diurchuk@luxoft.com>