### PR TITLE
Jenkinsfile: Vagrant to docker migration

### DIFF
--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -23,11 +23,14 @@ void buildARP(String variant, String imageName) {
         sh "rm -rf pelux-manifests/"
         sh "git clone https://github.com/Pelagicore/pelux-manifests.git -b ${branchName}"
         println("Using the specified branch for build: ${branchName}")
-
+        sh "cp -R ${arpDir} pelux-manifests/${arpDir}"
         dir('pelux-manifests') {
-            def code = load "ci-scripts/yocto.groovy"
-            String arpPath = "${env.WORKSPACE}/${arpDir}"
-            code.buildWithLayer(variant, imageName, arpDir, arpPath)
+            def customImage = docker.image("pelux/pelux-yocto:yoctouser")
+            customImage.inside("-v $WORKSPACE/pelux-manifests:/workspace -v /var/yocto-cache:/var/yocto-cache --cap-add=NET_ADMIN --device=/dev/net/tun") {
+                def code = load "ci-scripts/yocto2.groovy"
+                String arpPath = "/workspace/${arpDir}"
+                code.buildWithLayer(variant, imageName, arpDir, arpPath)
+            }
         }
     }
 }


### PR DESCRIPTION
In matter of meta layers replaceLayer mechanism was changed.
Now meta repository dir will be mounted within container,
and all other action will take place inside.
Everything else was inerhited from pelux-manifest

Signed-off-by: Dmytro Iurchuk <diurchuk@luxoft.com>